### PR TITLE
updating design system team name in codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @department-of-veterans-affairs/vsp-design-system-fe @department-of-veterans-affairs/pst-forms-library
+*   @department-of-veterans-affairs/platform-design-system-fe @department-of-veterans-affairs/pst-forms-library


### PR DESCRIPTION
## Description
Updating the name of the DST Github team in codeowners

## Original issue(s)
department-of-veterans-affairs/va-forms-system-core#0000

## Testing done

## Screenshots

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link to the original github issue has been provided
- [ ] No sensitive information (i.e. PII/credentials/internal URLs etc.) is captured in logging, hardcoded, or specs
