### PR TITLE
fix: required name prop for FullNameField

### DIFF
--- a/examples/simple-form/index.jsx
+++ b/examples/simple-form/index.jsx
@@ -88,7 +88,7 @@ const App = () => (
         <TextField name="foo" label="Example" required />
         {/* <DateField name="baz" required /> */}
         <CheckboxFieldGroup {...checkboxProps} />
-        <FullNameField />
+        <FullNameField name="fullName" label="fullName"/>
         <button type="submit" className="btn">
           {' '}
           submit

--- a/src/form-builder/FullNameField.tsx
+++ b/src/form-builder/FullNameField.tsx
@@ -6,26 +6,26 @@ import SelectField from './SelectField';
 import TextField from './TextField';
 
 const FullNameField = (props: FullNameProps): JSX.Element => {
-  const fieldName = props.fieldName ? props.fieldName : 'fullName';
+  const fieldName = props.name;
 
   return (
     <>
       <TextField
-        id="firstName"
+        id={`${fieldName}FirstName`}
         name={`${fieldName}.firstName`}
         label="Your first Name"
         required />
       <TextField
-        id="middleName"
+        id={`${fieldName}MiddleName`}
         name={`${fieldName}.middleName`}
         label="Your middle Name"/>
       <TextField
-        id="lastName"
+        id={`${fieldName}LastName`}
         name={`${fieldName}.lastName`}
         label="Your last Name"
         required />
       <SelectField
-        id="suffix"
+        id={`${fieldName}Suffix`}
         name={`${fieldName}.suffix`}
         label="Suffix">
           {Suffixes.map((suffix, idx) => <option key={`${idx}-${suffix}`}>{suffix}</option>)}

--- a/src/form-builder/types.ts
+++ b/src/form-builder/types.ts
@@ -52,6 +52,4 @@ export type CheckboxGroupProps = FieldProps<string> & {
  * ```
  * 
 */
-export type FullNameProps = FieldProps<string> & {
-  name: string;
-}
+export type FullNameProps = FieldProps<string>

--- a/src/form-builder/types.ts
+++ b/src/form-builder/types.ts
@@ -36,11 +36,22 @@ export type CheckboxGroupProps = FieldProps<string> & {
   options: CheckboxProps[];
 };
 
+/**
+ *
+ * @remarks
+ * The `name` prop must be passed in FullNameField component as it is used as object name.
+ * @example
+ * Here's a simple example:
+ * ```
+ * // <FullNameField name="fullName">
+ * {
+ *    fullName: {
+ *      // fields
+ *    }
+ * }
+ * ```
+ * 
+*/
 export type FullNameProps = FieldProps<string> & {
-  /**
-   * @defaultValue
-   * The default is `fullName` unless {@link FullNameProps.fieldName}
-   * is passed with custom name.
-   */
-  fieldName?: string | undefined;
+  name: string;
 }

--- a/test/form-builder/FullNameField.test.tsx
+++ b/test/form-builder/FullNameField.test.tsx
@@ -7,8 +7,8 @@ import { buildRenderForm, changeValue } from '../utils';
 import { FullNameField } from '../../src';
 
 const renderForm = buildRenderForm({});
-const testData = {
-  fullName: {
+const veteranTestData = {
+  veteranFullName: {
     firstName: 'Mark',
     middleName: 'W',
     lastName: 'Webb',
@@ -18,16 +18,16 @@ const testData = {
 
 const getInputs = (container: HTMLElement) => {
   return ({
-    firstNameInput: container.querySelector('#firstName') as HTMLElement,
-    middleNameInput: container.querySelector('#middleName') as HTMLElement,
-    lastNameInput: container.querySelector('#lastName') as HTMLElement,
-    suffixSelect: container.querySelector('#suffix') as HTMLElement
+    firstNameInput: container.querySelector('#veteranFullNameFirstName') as HTMLElement,
+    middleNameInput: container.querySelector('#veteranFullNameMiddleName') as HTMLElement,
+    lastNameInput: container.querySelector('#veteranFullNameLastName') as HTMLElement,
+    suffixSelect: container.querySelector('#veteranFullNameSuffix') as HTMLElement
   })
 } 
 
 describe('Form Builder - FullNameField', () => {
   test('renders', () => {
-    const { container } = renderForm(<FullNameField name={''} label={''} />)
+    const { container } = renderForm(<FullNameField name="veteranFullName" label="" />)
     const { firstNameInput, middleNameInput, lastNameInput, suffixSelect } = getInputs(container);
 
     expect(firstNameInput.getAttribute('label')).toEqual('Your first Name');
@@ -37,8 +37,8 @@ describe('Form Builder - FullNameField', () => {
   });
 
   test('renders initial value', () => {
-    const rf = buildRenderForm(testData);
-    const { container } = rf(<FullNameField name='' label='' />)
+    const rf = buildRenderForm(veteranTestData);
+    const { container } = rf(<FullNameField name="veteranFullName" label="" />)
     const { firstNameInput, middleNameInput, lastNameInput, suffixSelect } = getInputs(container);
 
     expect(firstNameInput.getAttribute('value')).toEqual('Mark')
@@ -48,12 +48,12 @@ describe('Form Builder - FullNameField', () => {
   });
 
   test('renders the default "required" validation error message', async () => {
-    const { container, getFormProps } = renderForm(<FullNameField name='' label='' />);
+    const { container, getFormProps } = renderForm(<FullNameField name="veteranFullName" label="" />);
     const { firstNameInput, lastNameInput } = getInputs(container);
 
     await waitFor(() => {
-      getFormProps().setFieldTouched('fullName.firstName');
-      getFormProps().setFieldTouched('fullName.lastName');
+      getFormProps().setFieldTouched('veteranFullName.firstName');
+      getFormProps().setFieldTouched('veteranFullName.lastName');
     });
 
     expect(firstNameInput.getAttribute('error')).toContain('provide a response')
@@ -61,16 +61,8 @@ describe('Form Builder - FullNameField', () => {
   });
 
   test('updates the formik state', async () => {
-    const veteranTestData = {
-      veteranFullName: {
-        firstName: 'Mark',
-        middleName: 'W',
-        lastName: 'Webb',
-        suffix: 'Sr'
-      }
-    }
     const rf = buildRenderForm(veteranTestData);
-    const { container, getFormProps } = rf(<FullNameField name='' label='' fieldName='veteranFullName'/>);
+    const { container, getFormProps } = rf(<FullNameField name="veteranFullName" label="" />);
     const { firstNameInput, middleNameInput, lastNameInput, suffixSelect } = getInputs(container);
 
     await changeValue(firstNameInput, 'Tony')


### PR DESCRIPTION
## Description
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
1. Passing dynamic id
2. Instead of a custom prop `name` need to be used to describe the object as shown below.
<img width="539" alt="fullname component" src="https://user-images.githubusercontent.com/22892911/165862719-254f9bf8-15bd-4b48-8458-1fffaff5b6cd.png">

## Original issue(s)
department-of-veterans-affairs/va-forms-system-core#219

## Testing done
Yes, changed the reader component to reflect the change in the functionality.

## Screenshots

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link to the original github issue has been provided
- [ ] No sensitive information (i.e. PII/credentials/internal URLs etc.) is captured in logging, hardcoded, or specs
