### PR TITLE
Fix/chain validation error

### DIFF
--- a/src/form-builder/EmailField.tsx
+++ b/src/form-builder/EmailField.tsx
@@ -29,7 +29,6 @@ const EmailField = (props: EmailProps): JSX.Element => {
       {...props}
       onChange={field.onChange}
       value={value}
-      required
       onBlur={() => helpers.setTouched(true)}
     />
   );

--- a/src/form-builder/PhoneField.tsx
+++ b/src/form-builder/PhoneField.tsx
@@ -30,7 +30,6 @@ const PhoneField = (props: PhoneProps): JSX.Element => {
       {...props}
       onChange={field.onChange}
       value={value}
-      required
       onBlur={() => helpers.setTouched(true)}
     />
   );

--- a/src/routing/Page.tsx
+++ b/src/routing/Page.tsx
@@ -28,7 +28,6 @@ export default function Page(props: PageProps): JSX.Element {
             className="btn prev"
             onClick={(event) => {
               event.preventDefault();
-              void submitForm();
               navigate(props.prevPage as To);
             }}
           >
@@ -42,7 +41,6 @@ export default function Page(props: PageProps): JSX.Element {
             className="btn next"
             onClick={(event) => {
               event.preventDefault();
-              void submitForm();
               navigate(props.nextPage as To);
             }}
           >

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -80,7 +80,8 @@ export const isValidEmail = <T>(
   props: FieldProps<T>
 ): ValidationFunctionResult<T> => {
   if (typeof emailString !== 'string') {
-    return 'Error: Email is not the correct type'; // This shouldn't happen
+    console.warn('emailString was not of type string');
+    return '';
   }
 
   // Comes from StackOverflow: http://stackoverflow.com/questions/46155/validate-email-address-in-javascript
@@ -97,7 +98,8 @@ export const isValidPhone = <T>(
   props: FieldProps<T>
 ): ValidationFunctionResult<T> => {
   if (typeof phoneString !== 'string') {
-    return 'Error: Phone is not the correct type'; // This shouldn't happen
+    console.warn('phoneString was not of type string');
+    return '';
   }
   function validPhone(value: string) {
     // Strip spaces, dashes, and parens
@@ -124,7 +126,8 @@ export const isValidSSN = <T>(
   props: FieldProps<T>
 ): ValidationFunctionResult<T> => {
   if (typeof ssnString !== 'string') {
-    return 'Error: ssnString is not the correct type.'; // This shouldn't happen
+    console.warn('ssnString was not of type string');
+    return '';
   }
 
   const noBadSameDigitNumber = range(0, 10).every((i) => {


### PR DESCRIPTION
## Description
Fixed the validation from alerting all required fields as soon as focus was ran on one field. This was being caused by the `submitForm()` action being ran on the first click from the introduction page, and once formik has submitted the data (or attempts to) all fields get set as `touched` which was throwing off the validation `meta.touched && meta.errored`

## Original issue(s)
[department-of-veterans-affairs/va-forms-system-core#339](https://app.zenhub.com/workspaces/forms-library---platform-spike-team-61b0ae1f2cd3c30014e8a5b0/issues/department-of-veterans-affairs/va-forms-system-core/339)

## Testing done
- [ ] All Tests are Passing
- [ ] Tested to be sure that only the field you focus on will put required validation error classes

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link to the original github issue has been provided
- [ ] No sensitive information (i.e. PII/credentials/internal URLs etc.) is captured in logging, hardcoded, or specs
