### PR TITLE
fix: updating using props for example pages

### DIFF
--- a/examples/burial-form/ClaimantInformation.jsx
+++ b/examples/burial-form/ClaimantInformation.jsx
@@ -7,7 +7,7 @@ import {
   RadioGroup
 } from '@department-of-veterans-affairs/va-forms-system-core';
 
-export default function ClaimantInformation() {
+export default function ClaimantInformation(props) {
   useEffect(() => {
     window.scrollTo({
       top: 0,

--- a/examples/burial-form/VeteranInformation.jsx
+++ b/examples/burial-form/VeteranInformation.jsx
@@ -9,7 +9,7 @@ import {
 } from '@department-of-veterans-affairs/va-forms-system-core';
 import { useFormikContext } from 'formik';
 
-export default function VeteranInformation() {
+export default function VeteranInformation(props) {
   useEffect(() => {
     window.scrollTo({
       top: 0,
@@ -22,7 +22,7 @@ export default function VeteranInformation() {
 
   return (
     <>
-      <Page title="Step 2 of 6: Deceased Veteran Information" nextPage="/" prevPage="/claimant-information">
+      <Page {...props} nextPage="/" prevPage="/claimant-information">
         <FullNameField name="veteranFullName" label="Veteran Full Name" />
 
         {


### PR DESCRIPTION
## Description
Fixing issues around props not being defined in claimant-information and adding the usage of props in the veteran-information page.

## Testing done
- [x] Unit Tests passing

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link to the original github issue has been provided
- [ ] No sensitive information (i.e. PII/credentials/internal URLs etc.) is captured in logging, hardcoded, or specs
