### PR TITLE
305 - Burial Allowance Page

### DIFF
--- a/examples/burial-form/BurialAllowance.jsx
+++ b/examples/burial-form/BurialAllowance.jsx
@@ -45,9 +45,10 @@ export default function BurialAllowance(props) {
             <va-alert status="warning"
                       background-only
                       class="vads-u-margin-y--2">
-                <span>If filing for a non-service-connected allowance, the Veteran’s burial date must be no more than 2 years from the current date. Find out if you still qualify. <a
-                  href="/burials-memorials/eligibility/"
-                  target="_blank">Learn about eligibility</a></span>
+                <span>
+                  If filing for a non-service-connected allowance, the Veteran’s burial date must be no more than 2 years from the current date. Find out if you still qualify.
+                  <a href="/burials-memorials/eligibility/" target="_blank">Learn about eligibility</a>
+                </span>
             </va-alert>
           )}
           {formikContext?.values?.burialAllowanceRequested === "vaMC" && (

--- a/examples/burial-form/BurialAllowance.jsx
+++ b/examples/burial-form/BurialAllowance.jsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import {Page, RadioGroup, TextField} from '@department-of-veterans-affairs/va-forms-system-core';
+import {useFormikContext} from "formik";
+
+export default function BurialAllowance(props) {
+  const formikContext = useFormikContext();
+
+  const getBurialAllowanceRequestedOptions = () => {
+    const allowanceTypes = [
+      {
+        label: "Service-connected death (for a Veteran death related to, or resulting from, a service-connected disability)",
+        value: "service",
+        key: 1
+      },
+      {
+        label: "Non-service-connected death",
+        value: "nonService",
+        key: 2
+      },
+    ];
+
+    const locationOfDeath = formikContext?.values?.locationOfDeath?.location;
+    if (locationOfDeath === 'vaMedicalCenter' || locationOfDeath === 'nursingHome') {
+      allowanceTypes.push(
+        {
+          label: "VA medical center death",
+          value: "vaMC",
+          key: 3
+        }
+      );
+    }
+    return allowanceTypes;
+  }
+
+  return (
+    <>
+      <Page {...props} nextPage="/benefits/plot-allowance" prevPage="/benefits/selection">
+        <div className={"form-expanding-group " + (formikContext?.values?.burialAllowanceRequested === "vaMC" ? "form-expanding-group-open" : "")}>
+          <RadioGroup name="burialAllowanceRequested"
+                      label="Type of burial allowance requested"
+                      required
+                      options={getBurialAllowanceRequestedOptions()}
+          />
+          {formikContext?.values?.burialAllowanceRequested === "nonService" && (
+            <va-alert status="warning"
+                      background-only
+                      class="vads-u-margin-y--2">
+                <span>If filing for a non-service-connected allowance, the Veteran’s burial date must be no more than 2 years from the current date. Find out if you still qualify. <a
+                  href="/burials-memorials/eligibility/"
+                  target="_blank">Learn about eligibility</a></span>
+            </va-alert>
+          )}
+          {formikContext?.values?.burialAllowanceRequested === "vaMC" && (
+            <div className="form-expanding-group-open">
+              <TextField label="Actual burial cost"
+                         name="burialCost"/>
+            </div>
+          )}
+        </div>
+
+        {formikContext?.values?.relationship?.type === "spouse" && (
+          <div className="vads-u-margin-y--3">
+            <RadioGroup
+              name="previouslyReceivedAllowance"
+              label="Did you previously receive a VA burial allowance?"
+              required
+              options={
+                [
+                  {label: "Yes", value: true, key: 1},
+                  {label: "No", value: false, key: 2},
+                ]
+              }
+            />
+          </div>
+        )}
+
+        {formikContext?.values?.relationship?.type === "other" && (
+          <div className="vads-u-margin-y--3">
+            <RadioGroup
+              name="benefitsUnclaimedRemains"
+              label="Are you seeking burial benefits for the unclaimed remains of a Veteran?"
+              required
+              options={
+                [
+                  {label: "Yes", value: true, key: 1},
+                  {label: "No", value: false, key: 2},
+                ]
+              }
+            />
+          </div>
+        )}
+      </Page>
+    </>
+  )
+}

--- a/examples/burial-form/index.jsx
+++ b/examples/burial-form/index.jsx
@@ -26,8 +26,8 @@ const BurialApp = (props) => {
         <Route path="/veteran-information" element={<VeteranInformation title="Deceased Veteran Information" />} />
         <Route path="/veteran-information/burial" element={<BurialInformation title="Deceased Veteran Information" />} />
         <Route path="/military-history/service-periods" element={<MilitaryServiceHistory title="Military Service History" />} />
-        <Route path="/benefits/plot-allowance" element={<PlotAllowance title="Benefits Selection" />} />
         <Route path="/benefits/burial-allowance" element={<BurialAllowance title="Burial allowance" />} />
+        <Route path="/benefits/plot-allowance" element={<PlotAllowance title="Benefits Selection" />} />
         <Route path="*" element={<NoMatch name="No Routes for App" />} />
       </FormRouter>
     </div>

--- a/examples/burial-form/index.jsx
+++ b/examples/burial-form/index.jsx
@@ -4,6 +4,7 @@ import { FormRouter } from '@department-of-veterans-affairs/va-forms-system-core
 import BurialIntroduction from './BurialIntroduction';
 import ClaimantInformation from './ClaimantInformation';
 import VeteranInformation from './VeteranInformation';
+import BurialAllowance from "./BurialAllowance";
 
 const NoMatch = (props) => (
   <main style={{ padding: '1rem' }}>
@@ -20,6 +21,7 @@ const BurialApp = (props) => {
         <Route index element={<BurialIntroduction title="Introduction Page" />} />
         <Route path="/claimant-information" element={<ClaimantInformation title="Claimant Information" />} />
         <Route path="/veteran-information" element={<VeteranInformation title="Deceased Veteran Information" />} />
+        <Route path="/benefits/burial-allowance" element={<BurialAllowance title="Burial allowance" />} />
         <Route path="*" element={<NoMatch name="No Routes for App" />} />
       </FormRouter>
     </div>


### PR DESCRIPTION
## Description
This PR adds the Burial Allowance page. The behavior of the page is as follows:

- The first radio button has 2 options by default, or 3 options if the location of death property is set to a VA Medical Center or a Nursing Home
  - If the second option (`Non-service-connected death`) is selected, a warning label should show below the radio button group
  - If the third option (`VA medical center death`) is selected, a currency input for Actual Burial Cost should show below the radio button group
 - A second radio button will only show if the Relationship.Type property (on the very first page of the form) is set to "spouse" or "other" 
   - If the property is set to "spouse", a T/F radio group with the label, "Did you previously receive a VA burial allowance?" will show
   - If the property is set to "other", a T/F radio group with the label, "Are you seeking burial benefits for the unclaimed remains of a Veteran?" will show

## Original issue(s)
department-of-veterans-affairs/va-forms-system-core#305

## Testing done

## Screenshots
![image](https://user-images.githubusercontent.com/15200011/171698226-5c6d4f44-09d9-4e3b-8115-86dc6709b82a.png)
![image](https://user-images.githubusercontent.com/15200011/171698258-f5f7b3d0-8842-4da9-a788-e80e77e66506.png)
![image](https://user-images.githubusercontent.com/15200011/171698287-116a7fbb-1b62-4d01-9616-f0e41ffa07b2.png)
![image](https://user-images.githubusercontent.com/15200011/171698434-36163d21-5d71-481e-9e9b-d9be3bcc5389.png)



## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link to the original github issue has been provided
- [ ] No sensitive information (i.e. PII/credentials/internal URLs etc.) is captured in logging, hardcoded, or specs
