### PR TITLE
fix: url routing is now working for serve-examples

### DIFF
--- a/examples/server.js
+++ b/examples/server.js
@@ -2,6 +2,7 @@
 const express = require('express');
 const webpack = require('webpack');
 const config = require('./webpack.config');
+const history = require('connect-history-api-fallback');
 const devMiddleware = require('webpack-dev-middleware');
 const hotReload = require('webpack-hot-middleware');
 
@@ -9,7 +10,12 @@ const app = express();
 const port = 3000;
 const compiler = webpack(config);
 
-app.use(devMiddleware(compiler));
+app.use(history());
+app.use(devMiddleware(compiler, 
+  { 
+    publicPath: config.output.publicPath
+  }
+));
 app.use(hotReload(compiler));
 
 app.listen(port, () => {

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -1,6 +1,5 @@
 const path = require('path');
 const fs = require('fs');
-const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 
@@ -27,6 +26,7 @@ const config = {
   output: {
     path: path.resolve(__dirname, outputDirectory),
     filename: '[name]/bundle.js',
+    publicPath: '/'
   },
   module: {
     rules: [

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "dist/**/*"
   ],
   "dependencies": {
+    "connect-history-api-fallback": "^1.6.0",
     "date-fns": "^2.28.0",
     "formik": "^2.2.9",
     "lodash": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1486,6 +1486,7 @@ __metadata:
     babel-jest: ^27.0.2
     babel-loader: ^8.2.2
     clean-webpack-plugin: ^4.0.0-alpha.0
+    connect-history-api-fallback: ^1.6.0
     css-loader: ^6.2.0
     date-fns: ^2.28.0
     eslint: ^7.28.0


### PR DESCRIPTION
## Description
This PR upgrades the webpack config to allow for `client side routing`. This will enable the users of our `burials example form` to be able to navigate between pages using the address bar and not only relying on the navigation links inside of the form.

## Original issue(s)
[department-of-veterans-affairs/va-forms-system-core#370](https://app.zenhub.com/workspaces/forms-library---platform-spike-team-61b0ae1f2cd3c30014e8a5b0/issues/department-of-veterans-affairs/va-forms-system-core/370)

## Testing done
- [ ] Able to type in any route past the `/` and get to that corresponding page

## Screenshots
- Page Loads here: 
![image](https://user-images.githubusercontent.com/22844722/172242722-712c0dce-5fc6-44df-8ca1-5399b383f437.png)

- Now type in the route `http://localhost:3000/veteran-information`:
![image](https://user-images.githubusercontent.com/22844722/172242836-9cdd6075-b3de-42ff-a0ef-8f5d81e666ae.png)

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link to the original github issue has been provided
- [ ] No sensitive information (i.e. PII/credentials/internal URLs etc.) is captured in logging, hardcoded, or specs
