### PR TITLE
366 Progress Bar Navigation - Intro and Confirmation page

### DIFF
--- a/examples/burial-form/ConfirmationPage.jsx
+++ b/examples/burial-form/ConfirmationPage.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import {Page} from '@department-of-veterans-affairs/va-forms-system-core';
+
+export default function ConfirmationPage(props) {
+  return (
+    <>
+      <Page {...props}>
+        <div></div>
+      </Page>
+    </>
+  )
+}

--- a/examples/burial-form/ReviewPage.jsx
+++ b/examples/burial-form/ReviewPage.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useFormikContext } from 'formik';
 import { Link } from 'react-router-dom';
 import { VaOnThisPage } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import {Page} from "@department-of-veterans-affairs/va-forms-system-core";
 
 /**
  * Transforms fields value into value that is more readable
@@ -349,7 +350,7 @@ export default function ReviewPage(props) {
   }
 
   return (
-    <>
+    <Page {...props} nextPage="/confirmation">
       <article>
         <h1>{props.title}</h1>
         <VaOnThisPage></VaOnThisPage>
@@ -365,6 +366,6 @@ export default function ReviewPage(props) {
           </section>
         )) }
       </article>
-    </>
+    </Page>
   )
 }

--- a/examples/burial-form/ReviewPage.jsx
+++ b/examples/burial-form/ReviewPage.jsx
@@ -350,7 +350,7 @@ export default function ReviewPage(props) {
   }
 
   return (
-    <Page {...props} nextPage="/confirmation">
+    <Page {...props} prevPage="/claimant-contact-information" nextPage="/confirmation">
       <article>
         <h1>{props.title}</h1>
         <VaOnThisPage></VaOnThisPage>

--- a/examples/burial-form/index.jsx
+++ b/examples/burial-form/index.jsx
@@ -12,6 +12,7 @@ import BurialAllowance from "./BurialAllowance";
 import BenefitsSelection from './BenefitsSelection';
 import ClaimantContactInformation from "./ClaimantContactInformation";
 import ReviewPage from './ReviewPage';
+import ConfirmationPage from "./ConfirmationPage";
 
 const NoMatch = (props) => (
   <main style={{ padding: '1rem' }}>
@@ -39,6 +40,7 @@ const BurialApp = (props) => {
         <Route path="/benefits/plot-allowance" element={<PlotAllowance title="Benefits Selection" />} />
         <Route path="/claimant-contact-information" element={<ClaimantContactInformation title="Claimant contact information" />} />
         <Route path="/review-and-submit" element={<ReviewPage title="Review Your Application" />} />
+        <Route path="/confirmation" element={<ConfirmationPage title="Confirmation Page" />} />
         <Route path="*" element={<NoMatch name="No Routes for App" />} />
       </FormRouter>
     </div>

--- a/src/routing/RouterProgress.tsx
+++ b/src/routing/RouterProgress.tsx
@@ -1,21 +1,29 @@
 import React, { useContext } from 'react';
 import ProgressBar from '../form-layout/ProgressBar';
 import { RouterContext } from './RouterContext';
+import { RouteInfo } from "./types";
+
+const RESTRICTED_ROUTES = ['/', '/confirmation']
 
 export default function RouterProgress(props: { route: string }): JSX.Element {
-  const { currentRoute, listOfRoutes } = useContext(RouterContext),
-    findIndex = listOfRoutes.indexOf(
-      listOfRoutes.filter((item) => item.path === currentRoute)[0]
+  const { currentRoute, listOfRoutes } = useContext(RouterContext);
+  const routesWithProgressBar = listOfRoutes.filter((route: RouteInfo) => !RESTRICTED_ROUTES.includes(route.path));
+
+  const findIndex = routesWithProgressBar.indexOf(
+      routesWithProgressBar.filter((item) => item.path === currentRoute)[0]
     ),
     currentIndex = findIndex >= 0 ? findIndex + 1 : 0,
-    stepTitle = listOfRoutes[findIndex]?.title,
-    numberOfSteps = listOfRoutes.length | 0;
+    stepTitle = routesWithProgressBar[findIndex]?.title,
+    numberOfSteps = routesWithProgressBar.length | 0;
 
-  return (
-    <ProgressBar
-      currentStep={currentIndex}
-      numberOfSteps={numberOfSteps}
-      stepTitle={stepTitle}
-    />
-  );
+  console.log(routesWithProgressBar, findIndex, currentIndex, stepTitle, numberOfSteps);
+  return findIndex > -1
+         ? (
+           <ProgressBar
+             currentStep={currentIndex}
+             numberOfSteps={numberOfSteps}
+             stepTitle={stepTitle}
+           />
+         )
+         : <></>;
 }

--- a/src/routing/RouterProgress.tsx
+++ b/src/routing/RouterProgress.tsx
@@ -16,7 +16,6 @@ export default function RouterProgress(props: { route: string }): JSX.Element {
     stepTitle = routesWithProgressBar[findIndex]?.title,
     numberOfSteps = routesWithProgressBar.length | 0;
 
-  console.log(routesWithProgressBar, findIndex, currentIndex, stepTitle, numberOfSteps);
   return findIndex > -1
          ? (
            <ProgressBar

--- a/test/routing/RouterContext.test.tsx
+++ b/test/routing/RouterContext.test.tsx
@@ -7,8 +7,16 @@ import { Page, RouterProps } from "../../src";
 import { render, waitFor } from "@testing-library/react";
 import RouterProgress from "../../src/routing/RouterProgress";
 
-const PageOne = (props: {title: string}) => (
+const IntroPage = (props: {title: string}) => (
   <Page 
+    {...props}
+    nextPage="/page-one">
+    <p>page one</p>
+  </Page>
+);
+
+const PageOne = (props: {title: string}) => (
+  <Page
     {...props}
     nextPage="/page-two">
     <p>page one</p>
@@ -112,7 +120,7 @@ describe('Routing - Router Context', () => {
   });
 
   test('Router Context passes correct information to the progress bar', async() => {
-    const routes = ["/", "/page-two"];
+    const routes = ["/", "/page-one", "/page-two"];
     const { container } = render(
       <MemoryRouter initialEntries={routes} initialIndex={1}>
         <FormRouterInternal
@@ -120,7 +128,8 @@ describe('Routing - Router Context', () => {
           formData={initialValues}
           title="Page Test"
           >
-          <Route index element={<PageOne title="Page One" />} />
+          <Route index element={<IntroPage title="Intro Page" />} />
+          <Route path="/page-one" element={<PageOne title="Page One" />} />
           <Route path="/page-two" element={<PageTwo title="Page Two" />} />
         </FormRouterInternal>
       </MemoryRouter>

--- a/test/routing/RouterProgress.test.tsx
+++ b/test/routing/RouterProgress.test.tsx
@@ -1,0 +1,90 @@
+import { RouterContextProvider } from "../../src/routing/RouterContext";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import React, { useState } from "react";
+import { Page, RouterProps } from "../../src";
+import RouterProgress from "../../src/routing/RouterProgress";
+import { render, waitFor } from "@testing-library/react";
+import { Formik } from "formik";
+import userEvent from "@testing-library/user-event";
+
+const FormRouterInternal = (props: RouterProps): JSX.Element => {
+  const [route, updateRoute] = useState('/');
+
+  return (
+    <RouterContextProvider
+      routes={props.children}
+      currentRoute={route}
+      updateRoute={updateRoute}>
+
+      <RouterProgress route={route}/>
+      <Formik
+        initialValues={props.formData}
+        onSubmit={(values, actions) => {
+          actions.setSubmitting(true);
+        }}
+      >
+        <Routes>{props.children}</Routes>
+      </Formik>
+    </RouterContextProvider>
+  )
+};
+
+const IndexPage = (props: { title: string }) => (
+  <Page
+    {...props}
+    nextPage="/about">
+    <p>Index</p>
+  </Page>
+);
+
+const AboutPage = (props: { title: string }) => (
+  <Page
+    {...props}
+    nextPage="/confirmation">
+    <p>About</p>
+  </Page>
+);
+
+const ConfirmationPage = (props: { title: string }) => (
+  <Page
+    {...props}
+    nextPage="/"
+  >
+    <p>Confirmation</p>
+  </Page>
+);
+
+describe('Routing - Router Progress', () => {
+  test('Progress Bars do not show on intro and confirmation pages', async() => {
+    const routes = ["/", "/about", "/confirmation"];
+    const { container } = render(
+      <MemoryRouter initialEntries={routes} initialIndex={0}>
+        <FormRouterInternal
+          basename="/"
+          formData={{}}
+          title="Page Test"
+        >
+          <Route index element={<IndexPage title="Index"/>}/>
+          <Route path="/about" element={<AboutPage title="About"/>}/>
+          <Route path="/confirmation" element={<ConfirmationPage title="Confirmation"/>}/>
+        </FormRouterInternal>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector('h2.vads-u-font-size--h4')).toBeNull();
+    });
+    userEvent.click(container.querySelector('button.next')!);
+
+    await waitFor(() =>
+                    expect(
+                      container.querySelector('h2.vads-u-font-size--h4')
+                        ?.innerHTML).toContain('Step 1 of 1: About')
+    );
+    userEvent.click(container.querySelector('button.next')!);
+
+    await waitFor(() => {
+      expect(container.querySelector('h2.vads-u-font-size--h4')).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Description
This PR ensures that the index page and confirmation pages in a form will not show the progress bar component, while the review page and other pages will.

## Original issue(s)
department-of-veterans-affairs/va-forms-system-core#0366

## Testing done

## Screenshots
<img width="927" alt="image" src="https://user-images.githubusercontent.com/15200011/173134737-c9f38120-f901-41a5-bc18-902d4de1c402.png">
<img width="786" alt="image" src="https://user-images.githubusercontent.com/15200011/173134760-37ceeaf4-bdf3-4cea-980b-f0621bd9d0f5.png">
<img width="712" alt="image" src="https://user-images.githubusercontent.com/15200011/173134787-12636804-642a-4425-82b6-8a96de65779c.png">

<img width="718" alt="image" src="https://user-images.githubusercontent.com/15200011/173134589-082a22d8-a251-4368-b779-24afe50bd7fa.png">

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link to the original github issue has been provided
- [ ] No sensitive information (i.e. PII/credentials/internal URLs etc.) is captured in logging, hardcoded, or specs
