### PR TITLE
fix: ssn mask on initial load

### DIFF
--- a/src/form-builder/SSNField.tsx
+++ b/src/form-builder/SSNField.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { FieldHookConfig, useField } from 'formik';
 
 import { FieldProps } from './types';
@@ -24,7 +24,13 @@ const SSNField = (props: SSNProps): JSX.Element => {
   );
   const id = props.id || props.name;
 
-  const [ssn, setSSN] = useState('');
+  const [ssn, setSSN] = useState(field.value ? field.value : '');
+
+  useEffect(() => {
+    if (field.value) {
+      setSSN(maskedValue(field.value));
+    }
+  }, []);
 
   const onFocus = () => {
     if (!field.value) return;
@@ -40,23 +46,27 @@ const SSNField = (props: SSNProps): JSX.Element => {
       helpers.setValue(ssnString);
       helpers.setTouched(true);
 
-      let maskedSSNString = '';
-
-      if (ssnString.length) {
-        const strippedSSN = ssnString.replace(/[- ]/g, '');
-        const maskedSSN = strippedSSN.replace(/^\d{1,5}/, (digit) =>
-          digit.replace(/\d/g, '●')
-        );
-
-        maskedSSNString = [
-          [...maskedSSN].splice(0, 3).join(''),
-          [...maskedSSN].splice(3, 2).join(''),
-          [...maskedSSN].splice(5).join(''),
-        ].join('-');
-      }
-
-      setSSN(maskedSSNString);
+      setSSN(maskedValue(ssnString));
     }, 0);
+  };
+
+  const maskedValue = (ssnString: string) => {
+    let maskedSSNString = '';
+
+    if (ssnString.length) {
+      const strippedSSN = ssnString.replace(/[- ]/g, '');
+      const maskedSSN = strippedSSN.replace(/^\d{1,5}/, (digit) =>
+        digit.replace(/\d/g, '●')
+      );
+
+      maskedSSNString = [
+        [...maskedSSN].splice(0, 3).join(''),
+        [...maskedSSN].splice(3, 2).join(''),
+        [...maskedSSN].splice(5).join(''),
+      ].join('-');
+    }
+
+    return maskedSSNString;
   };
 
   return (


### PR DESCRIPTION
## Description
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
This PR fixes the ssn mask on initial load if value exists.
- Once SSN value is entered and then navigating between pages or coming back from review page SSN will be masked and showed in the SSN Field.
 
## Original issue(s)
department-of-veterans-affairs/va-forms-system-core#384

## Testing done
Yes

## Screenshots
<img width="525" alt="ssn" src="https://user-images.githubusercontent.com/22892911/174392319-5a7c1fa8-0920-4047-9792-d59782f5500c.png">

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link to the original github issue has been provided
- [ ] No sensitive information (i.e. PII/credentials/internal URLs etc.) is captured in logging, hardcoded, or specs
