### PR TITLE
fix: clearing field condition for burial info

### DIFF
--- a/examples/burial-form/BurialInformation.jsx
+++ b/examples/burial-form/BurialInformation.jsx
@@ -24,6 +24,9 @@ export default function BurialInformation(props) {
         } else {
             setFieldValue('locationOfDeath.locationLabel', 'Other');
         }
+        if (values.locationOfDeath.location !== 'other') {
+            setFieldValue('locationOfDeath.other', undefined);
+        }
     },[values.locationOfDeath.location])
 
     return (


### PR DESCRIPTION
## Description
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
This PR fixes the 'Please specify' field for 'Where did the Veteran's death occur?' when other is deslected.

## Original issue(s)
department-of-veterans-affairs/va-forms-system-core#391

## Testing done
Yes

## Screenshots

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link to the original github issue has been provided
- [ ] No sensitive information (i.e. PII/credentials/internal URLs etc.) is captured in logging, hardcoded, or specs
