### PR TITLE
Ensure that each form has a camelCased name attribute value, based on the form's title prop

### DIFF
--- a/src/routing/Page.tsx
+++ b/src/routing/Page.tsx
@@ -3,6 +3,7 @@ import { Form } from 'formik';
 import { useNavigate, To, useSearchParams } from 'react-router-dom';
 import { PageProps } from './types';
 import { RouterContext } from './RouterContext';
+import { camelize } from '../utils/helpers';
 
 /**
  * Renders the page contents
@@ -20,7 +21,7 @@ export default function Page(props: PageProps): JSX.Element {
   return (
     <div>
       <h3>{props.title}</h3>
-      <Form>
+      <Form name={camelize(props.title)}>
         {props.children}
 
         {editPage && (

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -156,3 +156,16 @@ export const transformJSONSchema = (schema: any) => {
 export const CapitalizeFirstLetter = (value: string): string => {
   return value.trim().charAt(0).toUpperCase() + value.trim().slice(1);
 };
+
+/**
+ * A function that converts a string to camelCase
+ *
+ * @param string
+ */
+export const camelize = (string: string) => {
+  return string
+    .replace(/(?:^\w|[A-Z]|\b\w)/g, function (word, index) {
+      return index === 0 ? word.toLowerCase() : word.toUpperCase();
+    })
+    .replace(/\s+/g, '');
+};


### PR DESCRIPTION
## Description
Create a helper function that converts a string to camelCase. Use that function to render the name attribute by passing in the title of the form.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va-forms-system-core/issues/285

## Testing done
Yes

## Screenshots

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] Feature is covered by a unit test
- [x] A link to the original github issue has been provided
- [x] No sensitive information (i.e. PII/credentials/internal URLs etc.) is captured in logging, hardcoded, or specs
