### PR TITLE
Feat/495 add change handler to text field

### DIFF
--- a/doc-extraction/va-forms-system-core.api.md
+++ b/doc-extraction/va-forms-system-core.api.md
@@ -118,6 +118,7 @@ export const emailRegex: RegExp;
 export type FieldProps<V> = Omit<FieldHookConfig<V>, 'required'> & {
     label: string;
     id?: string;
+    onValueChange?: (e: Event) => void;
     required?: boolean | string;
 };
 

--- a/docs/reference/va-forms-system-core.fieldprops.md
+++ b/docs/reference/va-forms-system-core.fieldprops.md
@@ -10,6 +10,7 @@
 export declare type FieldProps<V> = Omit<FieldHookConfig<V>, 'required'> & {
     label: string;
     id?: string;
+    onValueChange?: (e: Event) => void;
     required?: boolean | string;
 };
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/va-forms-system-core",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Department of Veterans Affairs Forms System Core.",
   "main": "dist/index.js",
   "module": "dist/va-forms-system-core.cjs.production.min.js",

--- a/src/form-builder/TextField.tsx
+++ b/src/form-builder/TextField.tsx
@@ -13,6 +13,11 @@ const TextField = (props: FieldProps<string>): JSX.Element => {
   const [field, meta] = useField(withValidation as FieldHookConfig<string>);
   const id = props.id || props.name;
 
+  const onChange = (e: Event) => {
+    field.onChange(e)
+    if (props.onValueChange) props.onValueChange(e)
+  }
+
   return (
     <VaTextInput
       id={id}
@@ -20,7 +25,7 @@ const TextField = (props: FieldProps<string>): JSX.Element => {
       label={props.label}
       required={!!props.required}
       {...field}
-      onInput={field.onChange}
+      onInput={onChange}
       error={(meta.touched && meta.error) || undefined}
     />
   );

--- a/src/form-builder/types.ts
+++ b/src/form-builder/types.ts
@@ -3,6 +3,7 @@ import { FieldHookConfig } from 'formik';
 export type FieldProps<V> = Omit<FieldHookConfig<V>, 'required'> & {
   label: string;
   id?: string;
+  onValueChange?: (e: Event) => void;
   /**
    * If `required` is true, the default message will be used. If `required` is a
    * string, it will be used as the error message.

--- a/test/form-builder/TextField.test.tsx
+++ b/test/form-builder/TextField.test.tsx
@@ -73,6 +73,17 @@ describe('Form Builder - TextField', () => {
     expect(spy).toBeCalled();
   });
 
+  test('handles value change using a function', async () => {
+    const spy = jest.fn();
+    const { container } = renderForm(
+      <TextField name="thing" label="The Thing" validate={spy} />
+    );
+    const input = getInput(container);
+
+    await changeValue(input, 'asdf', 'input');
+    expect(spy).toBeCalled();
+  });
+
   test('updates the formik state', async () => {
     const rf = buildRenderForm({ thing: 'foo' });
     const { container, getFormProps } = rf(


### PR DESCRIPTION
## Description
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->

Adds an `onValueChange` prop to the TextField component to allow for a function to be passed for handling value change events. The existing Formik `field.onChange` would still fire but the additional function prop could also be called if it is provided. 

## Original issue(s)
https://github.com/department-of-veterans-affairs/va-forms-system-core/issues/495

## Testing done

Added a unit test for this new prop

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link to the original github issue has been provided
- [ ] No sensitive information (i.e. PII/credentials/internal URLs etc.) is captured in logging, hardcoded, or specs
