### PR TITLE
fix: reverting back to yarn npm publish for now

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -37,14 +37,19 @@ jobs:
         ssm_parameter: /devops/VA_VSP_BOT_NPM_TOKEN
         env_variable_name: VA_VSP_BOT_NPM_TOKEN
 
-    - name: Get Github Token password
-      uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-      with:
-        ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
-        env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
-
-    - name: Run npx semantic-release, create Github Release, and Publish NPM package
-      run: npx semantic-release
+    - name: Publish build artifacts to NPM
+      run: yarn npm publish --access public --tolerate-republish
       env:
-        NPM_TOKEN: ${{ env.VA_VSP_BOT_NPM_TOKEN }}
-        GH_TOKEN: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
+        YARN_NPM_AUTH_TOKEN: ${{ env.VA_VSP_BOT_NPM_TOKEN }}
+
+    # - name: Get Github Token password
+    #   uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+    #   with:
+    #     ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+    #     env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+
+    # - name: Run npx semantic-release, create Github Release, and Publish NPM package
+    #   run: npx semantic-release
+    #   env:
+    #     NPM_TOKEN: ${{ env.VA_VSP_BOT_NPM_TOKEN }}
+    #     GH_TOKEN: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
Reverting this change for now until I get my branch configured properly with the new Token needed.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link to the original github issue has been provided
- [ ] No sensitive information (i.e. PII/credentials/internal URLs etc.) is captured in logging, hardcoded, or specs
