### PR TITLE
fix: adding component-library to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/va-forms-system-core",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Department of Veterans Affairs Forms System Core.",
   "main": "dist/index.js",
   "module": "dist/va-forms-system-core.cjs.production.min.js",

--- a/package.json
+++ b/package.json
@@ -121,6 +121,9 @@
     "webpack-dev-server": "^3.11.2",
     "webpack-hot-middleware": "^2.25.0"
   },
+  "peerDependencies": {
+    "@department-of-veterans-affairs/component-library": "^11.0.0"
+  },
   "lint-staged": {
     "src/**/*.{js,ts,jsx,tsx}": "eslint --cache --fix",
     "src/**/*.{js,ts,jsx,tsx,css,md}": "prettier --write"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1536,6 +1536,8 @@ __metadata:
     webpack-dev-middleware: ^5.0.0
     webpack-dev-server: ^3.11.2
     webpack-hot-middleware: ^2.25.0
+  peerDependencies:
+    "@department-of-veterans-affairs/component-library": ^11.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description
Attempting to copy the `@department-of-veteran-affairs/component-library` to the peerDependencies list to see if we can get past some testing errors inside of `vets-website`.

## Original issue(s)
[department-of-veterans-affairs/va-forms-system-core#258](https://app.zenhub.com/workspaces/forms-library---platform-spike-team-61b0ae1f2cd3c30014e8a5b0/issues/department-of-veterans-affairs/va-forms-system-core/258)

## Testing done
- [ ] Unit Tests Passing

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link to the original github issue has been provided
- [ ] No sensitive information (i.e. PII/credentials/internal URLs etc.) is captured in logging, hardcoded, or specs
