### PR TITLE
fix: reverting peerDependencies and bumping package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/va-forms-system-core",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Department of Veterans Affairs Forms System Core.",
   "main": "dist/index.js",
   "module": "dist/va-forms-system-core.cjs.production.min.js",
@@ -120,9 +120,6 @@
     "webpack-dev-middleware": "^5.0.0",
     "webpack-dev-server": "^3.11.2",
     "webpack-hot-middleware": "^2.25.0"
-  },
-  "peerDependencies": {
-    "@department-of-veterans-affairs/component-library": "^11.0.0"
   },
   "lint-staged": {
     "src/**/*.{js,ts,jsx,tsx}": "eslint --cache --fix",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1536,8 +1536,6 @@ __metadata:
     webpack-dev-middleware: ^5.0.0
     webpack-dev-server: ^3.11.2
     webpack-hot-middleware: ^2.25.0
-  peerDependencies:
-    "@department-of-veterans-affairs/component-library": ^11.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description
Reverting the peerDependency change because it had no positive effect on the broken vets-website tests.

Also bumping package.json version so that new changes are available to use for Adam's PR.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link to the original github issue has been provided
- [ ] No sensitive information (i.e. PII/credentials/internal URLs etc.) is captured in logging, hardcoded, or specs
