### PR TITLE
fix: changing name to NPM_TOKEN again

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -46,5 +46,5 @@ jobs:
       - name: Run npx semantic-release, create Github Release, and Publish NPM package
         run: npx semantic-release
         env:
-          YARN_NPM_AUTH_TOKEN: ${{ env.VA_VSP_BOT_NPM_TOKEN }}
+          NPM_TOKEN: ${{ env.VA_VSP_BOT_NPM_TOKEN }}
           GH_TOKEN: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
Changing the NPM_TOKEN name to match what semantic-release needs.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link to the original github issue has been provided
- [ ] No sensitive information (i.e. PII/credentials/internal URLs etc.) is captured in logging, hardcoded, or specs
