### PR TITLE
fix: adding permissions for bot to push to main

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -37,19 +37,19 @@ jobs:
           ssm_parameter: /devops/VA_VSP_BOT_NPM_TOKEN
           env_variable_name: VA_VSP_BOT_NPM_TOKEN
 
-      - name: Publish build artifacts to NPM
-        run: yarn npm publish --access public --tolerate-republish
-        env:
-          YARN_NPM_AUTH_TOKEN: ${{ env.VA_VSP_BOT_NPM_TOKEN }}
-
-      # - name: Get Github Token password
-      #   uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-      #   with:
-      #     ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
-      #     env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
-
-      # - name: Run npx semantic-release, create Github Release, and Publish NPM package
-      #   run: npx semantic-release
+      # - name: Publish build artifacts to NPM
+      #   run: yarn npm publish --access public --tolerate-republish
       #   env:
-      #     NPM_TOKEN: ${{ env.VA_VSP_BOT_NPM_TOKEN }}
-      #     GH_TOKEN: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
+      #     YARN_NPM_AUTH_TOKEN: ${{ env.VA_VSP_BOT_NPM_TOKEN }}
+
+      - name: Get Github Token password
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        with:
+          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+
+      - name: Run npx semantic-release, create Github Release, and Publish NPM package
+        run: npx semantic-release
+        env:
+          NPM_TOKEN: ${{ env.VA_VSP_BOT_NPM_TOKEN }}
+          GH_TOKEN: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
In this PR I have added the bot to the list of authorized users to try and bypass the commit issue.

By adding the bot to bypass the branch protection rules SHOULD allow the bot to commit the version upgrade to package.json and complete the publish command.

## Original issue(s)
[department-of-veterans-affairs/va-forms-system-core#432](https://app.zenhub.com/workspaces/forms-library---platform-spike-team-61b0ae1f2cd3c30014e8a5b0/issues/department-of-veterans-affairs/va-forms-system-core/432)

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link to the original github issue has been provided
- [ ] No sensitive information (i.e. PII/credentials/internal URLs etc.) is captured in logging, hardcoded, or specs
