### PR TITLE
Fix/semantic with manual bump

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,9 @@
 ## Description
+
 <!-- Please include a description of the change and context. What would a code reviewer, or a future dev, need to know about this PR in order to understand why this PR is necessary? This could include dependencies introduced, changes in behavior, pointers to more detailed documentation. The description should be more than a link to an issue.  -->
 
 ## Original issue(s)
+
 department-of-veterans-affairs/va-forms-system-core#0000
 
 ## Testing done
@@ -9,6 +11,8 @@ department-of-veterans-affairs/va-forms-system-core#0000
 ## Screenshots
 
 ## Definition of done
+
+- [ ] Package.json version has been updated to match Github release tag
 - [ ] Documentation has been updated, if applicable
 - [ ] A link to the original github issue has been provided
 - [ ] No sensitive information (i.e. PII/credentials/internal URLs etc.) is captured in logging, hardcoded, or specs

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -37,19 +37,18 @@ jobs:
           ssm_parameter: /devops/VA_VSP_BOT_NPM_TOKEN
           env_variable_name: VA_VSP_BOT_NPM_TOKEN
 
+      - name: Get Github Token password
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        with:
+          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+
+      - name: Run npx semantic-release, create Github Release, and Publish NPM package
+        run: npx semantic-release
+        env:
+          GH_TOKEN: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
+
       - name: Publish build artifacts to NPM
         run: yarn npm publish --access public --tolerate-republish
         env:
           YARN_NPM_AUTH_TOKEN: ${{ env.VA_VSP_BOT_NPM_TOKEN }}
-
-      # - name: Get Github Token password
-      #   uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-      #   with:
-      #     ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
-      #     env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
-
-      # - name: Run npx semantic-release, create Github Release, and Publish NPM package
-      #   run: npx semantic-release
-      #   env:
-      #     NPM_TOKEN: ${{ env.VA_VSP_BOT_NPM_TOKEN }}
-      #     GH_TOKEN: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/va-forms-system-core",
-  "version": "0.0.10",
+  "version": "1.0.1",
   "description": "Department of Veterans Affairs Forms System Core.",
   "main": "dist/index.js",
   "module": "dist/va-forms-system-core.cjs.production.min.js",
@@ -37,7 +37,6 @@
         }
       ],
       "@semantic-release/release-notes-generator",
-      "@semantic-release/npm",
       "@semantic-release/github",
       "@semantic-release/git"
     ]
@@ -78,7 +77,6 @@
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/commit-analyzer": "^9.0.1",
     "@semantic-release/git": "^10.0.1",
-    "@semantic-release/npm": "^8.0.3",
     "@semantic-release/release-notes-generator": "^10.0.2",
     "@size-limit/preset-small-lib": "^5.0.1",
     "@testing-library/jest-dom": "^5.16.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1488,7 +1488,6 @@ __metadata:
     "@semantic-release/changelog": ^6.0.1
     "@semantic-release/commit-analyzer": ^9.0.1
     "@semantic-release/git": ^10.0.1
-    "@semantic-release/npm": ^8.0.3
     "@semantic-release/release-notes-generator": ^10.0.2
     "@size-limit/preset-small-lib": ^5.0.1
     "@testing-library/jest-dom": ^5.16.4
@@ -2704,7 +2703,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@semantic-release/npm@npm:^8.0.0, @semantic-release/npm@npm:^8.0.3":
+"@semantic-release/npm@npm:^8.0.0":
   version: 8.0.3
   resolution: "@semantic-release/npm@npm:8.0.3"
   dependencies:


### PR DESCRIPTION
## Description
This PR removes the semantic-release/npm plugin and keeps the `yarn publish` action to be able to still use semantic versioning for our Github releases and tags, but requires manually updating the `package.json` file.

## Original issue(s)
[department-of-veterans-affairs/va-forms-system-core#432](https://app.zenhub.com/workspaces/forms-library---platform-spike-team-61b0ae1f2cd3c30014e8a5b0/issues/department-of-veterans-affairs/va-forms-system-core/432)

## Definition of done
- [x] Package.json version has been updated to match Github release tag
- [x] Documentation has been updated, if applicable
- [x] A link to the original github issue has been provided
- [x] No sensitive information (i.e. PII/credentials/internal URLs etc.) is captured in logging, hardcoded, or specs
