### PR TITLE
fix: bumping npm version to match Github version

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Run npx semantic-release, create Github Release, and Publish NPM package
         run: npx semantic-release
         env:
+          NPM_TOKEN: ${{ env.VA_VSP_BOT_NPM_TOKEN }}
           GH_TOKEN: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
 
       - name: Publish build artifacts to NPM

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/va-forms-system-core",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "description": "Department of Veterans Affairs Forms System Core.",
   "main": "dist/index.js",
   "module": "dist/va-forms-system-core.cjs.production.min.js",


### PR DESCRIPTION
## Description

Bumping the version to match the github version.

- [ ] Package.json version has been updated to match Github release tag
- [ ] Documentation has been updated, if applicable
- [ ] A link to the original github issue has been provided
- [ ] No sensitive information (i.e. PII/credentials/internal URLs etc.) is captured in logging, hardcoded, or specs
