### PR TITLE
feat: remove unused resolution for npm/chalk

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,9 +119,6 @@
     "webpack-dev-server": "^3.11.2",
     "webpack-hot-middleware": "^2.25.0"
   },
-  "resolutions": {
-    "npm/chalk": "^4.1.2"
-  },
   "lint-staged": {
     "src/**/*.{js,ts,jsx,tsx}": "eslint --cache --fix",
     "src/**/*.{js,ts,jsx,tsx,css,md}": "prettier --write"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5490,6 +5490,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chalk@npm:*":
+  version: 5.0.1
+  resolution: "chalk@npm:5.0.1"
+  checksum: 7b45300372b908f0471fbf7389ce2f5de8d85bb949026fd51a1b95b10d0ed32c7ed5aab36dd5e9d2bf3191867909b4404cef75c5f4d2d1daeeacd301dd280b76
+  languageName: node
+  linkType: hard
+
 "chalk@npm:^2.0.0, chalk@npm:^2.1.0, chalk@npm:^2.3.2, chalk@npm:^2.4.1, chalk@npm:^2.4.2":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
@@ -5511,7 +5518,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.2":
+"chalk@npm:^4.0.0, chalk@npm:^4.1.0":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:


### PR DESCRIPTION
## Description

Removing an unused resolution from the package.json file around npm/chalk, and attempting to kick of the `feat:` Github release information from last PR.

- [ ] Package.json version has been updated to match Github release tag
- [ ] Documentation has been updated, if applicable
- [ ] A link to the original github issue has been provided
- [ ] No sensitive information (i.e. PII/credentials/internal URLs etc.) is captured in logging, hardcoded, or specs
