### PR TITLE
fix(479): validate form errors on back to review button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formulate",
-  "version": "0.0.1",
+  "version": "1.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/va-forms-system-core",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Department of Veterans Affairs Forms System Core.",
   "main": "dist/index.js",
   "module": "dist/va-forms-system-core.cjs.production.min.js",

--- a/src/routing/Page.tsx
+++ b/src/routing/Page.tsx
@@ -45,12 +45,18 @@ export default function Page(props: PageProps): JSX.Element {
       {editPage && (
         <div>
           <VaButton
-            onClick={() => {
-              navigate(
-                `/review-and-submit${
-                  sourceAnchor ? `#${sourceAnchor}` : ''
-                }` as To
-              );
+            onClick={(event: Event) => {
+              if (Object.keys(state.errors).length > 0) {
+                state.handleSubmit();
+                event.preventDefault();
+              } else {
+                state.handleSubmit();
+                navigate(
+                  `/review-and-submit${
+                    sourceAnchor ? `#${sourceAnchor}` : ''
+                  }` as To
+                );
+              }
             }}
             text="Back to Review Page"
           />


### PR DESCRIPTION
## Description

This PR forces validation on clicking the `Back To Review Page` button in preparation for the fix described in the ticket below.

## Original issue(s)

[department-of-veterans-affairs/va-forms-system-core#479](https://app.zenhub.com/workspaces/forms-library---platform-spike-team-61b0ae1f2cd3c30014e8a5b0/issues/department-of-veterans-affairs/va-forms-system-core/479)

## Testing done

- [x] Unit Tests Pass

## Definition of done

- [x] Package.json version has been updated to match Github release tag
- [x] Documentation has been updated, if applicable
- [x] A link to the original github issue has been provided
- [x] No sensitive information (i.e. PII/credentials/internal URLs etc.) is captured in logging, hardcoded, or specs
