### PR TITLE
fix(#547): Ensure that no duplicate IDs are found on the review page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/va-forms-system-core",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Department of Veterans Affairs Forms System Core.",
   "main": "dist/index.js",
   "module": "dist/va-forms-system-core.cjs.production.min.js",

--- a/src/form-data/ReviewPage.tsx
+++ b/src/form-data/ReviewPage.tsx
@@ -152,21 +152,17 @@ export default function ReviewPage(props: { title: string }) {
 
         {listOfPages.map((page) => {
           return (
-            <section
-              id={page.id}
-              key={page.id}
-              className="review-page--page-info"
-            >
+            <section key={page.id} className="review-page--page-info">
               <div className="review-page--page-heading vads-u-justify-content--space-between vads-l-row vads-u-border-bottom--1px vads-u-border-color--link-default">
-                <h2
-                  id={page.id}
-                  className="vads-u-font-size--h3 vads-u-flex--1 review-page--page-heading--text"
-                >
+                <h2 className="vads-u-font-size--h3 vads-u-flex--1 review-page--page-heading--text">
                   {page.title}
                 </h2>
+
                 <Link
                   to={page.path + '?edit=true&source=' + page.id}
                   className="vads-u-margin-bottom--1p5 review-page--page-heading--link"
+                  id={`edit${page.id}`}
+                  aria-label={`Edit ${page.title}`}
                 >
                   Edit
                 </Link>

--- a/src/routing/Page.tsx
+++ b/src/routing/Page.tsx
@@ -80,6 +80,16 @@ export default function Page(props: PageProps): JSX.Element {
                     sourceAnchor ? `#${sourceAnchor}` : ''
                   }` as To
                 );
+
+                // Allow time for render before finding the edit button and focusing on it
+                setTimeout(() => {
+                  const editLink = document.getElementById(
+                    `edit${sourceAnchor ? sourceAnchor : ''}`
+                  );
+
+                  // Only fire the focus method if the edit link exists
+                  editLink?.focus();
+                }, 0);
               }
             }}
             text="Back to Review Page"


### PR DESCRIPTION
## Description

Ensures that no duplicate IDs are found on the review page. Ensures that the Edit link on the review page has an adequate aria-label attribute, so that screen reader users know what they are about to edit. Also ensure that focus is set on the appropriate Edit link when the user activates the Back To Review Page button, so they put back to the place that initiated the edit view.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va-forms-system-core/issues/547

## Testing done
Yes

## Screenshots

https://user-images.githubusercontent.com/5934582/185257142-3f64f6e0-f5b1-4955-88ed-7cd28d39c495.mov

## Definition of done

- [ ] Package.json version has been updated to match Github release tag
- [ ] Documentation has been updated, if applicable
- [ ] A link to the original github issue has been provided
- [ ] No sensitive information (i.e. PII/credentials/internal URLs etc.) is captured in logging, hardcoded, or specs
