### PR TITLE
fix(privacy): add privacy statement back to review page

### DIFF
--- a/src/form-data/ReviewPage.tsx
+++ b/src/form-data/ReviewPage.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom-v5-compat';
 import { VaOnThisPage } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { Page } from '../routing';
 import { FieldObject } from './types';
+import { CheckboxField } from '../form-builder';
 
 import { parseDate } from '../utils/helpers';
 import { PageContext } from './PageContext';
@@ -171,6 +172,32 @@ export default function ReviewPage(props: { title: string }) {
             </section>
           );
         })}
+
+        <div>
+          <p className="vads-u-padding-y--2">
+            <strong>Note:</strong> According to federal law, there are criminal
+            penalties, including a fine and/or imprisonment for up to 5 years,
+            for withholding information or for providing incorrect information.
+            (See 18 U.S.C. 1001)
+          </p>
+          <CheckboxField
+            required="You must accept the privacy policy before continuing."
+            name="privacyAgreementAccepted"
+            label="I have read and accept the privacy policy"
+            description={null}
+          >
+            <p slot="description">
+              Please read and accept the{' '}
+              <a
+                aria-label="Privacy policy, will open in new tab"
+                target="_blank"
+                href="/privacy-policy/"
+              >
+                privacy policy
+              </a>
+            </p>
+          </CheckboxField>
+        </div>
       </article>
     </Page>
   );


### PR DESCRIPTION
## Description

Adding the privacy checkbox back to ReviewPage component so testing can continue

## Testing done
- [ ] Unit Test passed

## Screenshots
<img width="704" alt="image" src="https://user-images.githubusercontent.com/22844722/185961038-1f66c2b5-4ff1-4182-ae48-c073b23124dd.png">

## Definition of done

- [ ] Package.json version has been updated to match Github release tag
- [ ] Documentation has been updated, if applicable
- [ ] A link to the original github issue has been provided
- [ ] No sensitive information (i.e. PII/credentials/internal URLs etc.) is captured in logging, hardcoded, or specs
