### PR TITLE
Set value of the checkbox group to `false` if there isn’t a value defined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/va-forms-system-core",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Department of Veterans Affairs Forms System Core.",
   "main": "dist/index.js",
   "module": "dist/va-forms-system-core.cjs.production.min.js",

--- a/src/form-builder/CheckboxFieldGroup.tsx
+++ b/src/form-builder/CheckboxFieldGroup.tsx
@@ -19,6 +19,8 @@ const CheckboxFieldGroup = (props: CheckboxGroupProps): JSX.Element => {
   );
 
   useEffect(() => {
+    // Only set the value to false if there isn't a value defined
+    if (field.value) return;
     helpers.setValue(false);
   }, []);
 


### PR DESCRIPTION
## Description
This fix prevents a bug with the burial demo form where the user is unable to proceed to the next step due to the checkbox group's value being set to `false`, even if its value has been set.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va-forms-system-core/issues/593

## Screenshots
https://user-images.githubusercontent.com/5934582/188240599-96732709-3b97-4878-82cd-d977c8cadc52.mov

## Definition of done
- [ ] Package.json version has been updated to match Github release tag
- [ ] Documentation has been updated, if applicable
- [ ] A link to the original github issue has been provided
- [ ] No sensitive information (i.e. PII/credentials/internal URLs etc.) is captured in logging, hardcoded, or specs
